### PR TITLE
Remove redundant /home route (just use index)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,11 +36,10 @@ const App = () => (
       <Routes>
         <Route element={<Base />}>
           <Route index element={<Home />} />
-          <Route path="home" element={<Home />} />
           <Route path="about" element={<About />} />
           <Route path="organization" element={<Organization />} />
           <Route path="faq" element={<FAQ />} />
-          <Route path="*" element={<Navigate to="/home" replace />} />
+          <Route path="*" element={<Navigate to="/" replace />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/components/Base.tsx
+++ b/src/components/Base.tsx
@@ -17,15 +17,20 @@ const ICONS = {
   faq: QuestionAnswer,
 } as const;
 
+const ROUTE_NAME_TO_ROUTE = {
+  home: "/",
+  about: "/about",
+  organization: "/organization",
+  faq: "/faq",
+} as const;
+
 export const Base = () => {
   const { t } = useTranslation();
   const { pathname } = useLocation();
 
-  const currentRoute = pathname === "/" ? "/home" : pathname;
-
   useEffect(() => {
     window.scrollTo(0, 0);
-  }, [currentRoute]);
+  }, [pathname]);
 
   return (
     <Box minHeight="100vh" display="flex" flexDirection="column">
@@ -34,10 +39,10 @@ export const Base = () => {
         sx={{ position: "sticky", bottom: 0, left: 0, right: 0, zIndex: 1100 }}
         elevation={2}
       >
-        <BottomNavigation showLabels value={currentRoute}>
+        <BottomNavigation showLabels value={pathname}>
           {ROUTES.map((r) => {
             const Icon = ICONS[r];
-            const route = `/${r}`;
+            const route = ROUTE_NAME_TO_ROUTE[r];
 
             return (
               <BottomNavigationAction


### PR DESCRIPTION
Instead of routing to `/home` via the navigation menu and when an unknown route is encountered, refactor to just use the index `/` route.

Remove the `/home` route.