### PR TITLE
Support localization

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { createTheme, ThemeProvider } from "@mui/material/styles";
 import { red } from "@mui/material/colors";
 import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import { Base } from "./components/Base";
-import { DEFAULT_LOCALE, resources } from "./locale";
+import { getLocaleOrFallback, resources, SAVED_LOCALE } from "./locale";
 import { Home } from "./pages/Home";
 import { About } from "./pages/About";
 import { Organization } from "./pages/Organization";
@@ -12,7 +12,6 @@ import { FAQ } from "./pages/FAQ";
 
 i18n.use(initReactI18next).init({
   resources,
-  lng: DEFAULT_LOCALE,
   interpolation: {
     escapeValue: false,
   },
@@ -30,20 +29,34 @@ const theme = createTheme({
   },
 });
 
-const App = () => (
-  <ThemeProvider theme={theme}>
-    <BrowserRouter>
-      <Routes>
-        <Route element={<Base />}>
-          <Route index element={<Home />} />
-          <Route path="about" element={<About />} />
-          <Route path="organization" element={<Organization />} />
-          <Route path="faq" element={<FAQ />} />
-          <Route path="*" element={<Navigate to="/" replace />} />
-        </Route>
-      </Routes>
-    </BrowserRouter>
-  </ThemeProvider>
-);
+const App = () => {
+  const savedLocale = localStorage.getItem(SAVED_LOCALE) as string;
+  const locale = getLocaleOrFallback(savedLocale);
+
+  return (
+    <ThemeProvider theme={theme}>
+      <BrowserRouter>
+        <Routes>
+          <Route element={<Base />}>
+            <Route path=":locale/">
+              <Route index element={<Home />} />
+              <Route path="about" element={<About />} />
+              <Route path="organization" element={<Organization />} />
+              <Route path="faq" element={<FAQ />} />
+            </Route>
+            {["about", "organization", "faq"].map((route) => (
+              <Route
+                key={route}
+                path={route}
+                element={<Navigate to={`/${locale}/${route}`} replace />}
+              />
+            ))}
+            <Route path="*" element={<Navigate to={locale} replace />} />
+          </Route>
+        </Routes>
+      </BrowserRouter>
+    </ThemeProvider>
+  );
+};
 
 export default App;

--- a/src/components/Base.tsx
+++ b/src/components/Base.tsx
@@ -30,6 +30,7 @@ const ROUTE_NAME_TO_ROUTE = {
 export const Base = () => {
   const { t } = useTranslation();
   const { pathname } = useLocation();
+  const pathWithoutLocale = pathname.split("/").at(-1);
   const params = useParams();
   const locale = getLocaleOrFallback(params.locale as string);
 
@@ -40,7 +41,7 @@ export const Base = () => {
 
   useEffect(() => {
     window.scrollTo(0, 0);
-  }, [pathname]);
+  }, [pathWithoutLocale]);
 
   return (
     <Box minHeight="100vh" flex={1} display="flex" flexDirection="column">
@@ -51,17 +52,18 @@ export const Base = () => {
         sx={{ position: "sticky", bottom: 0, left: 0, right: 0, zIndex: 1100 }}
         elevation={2}
       >
-        <BottomNavigation showLabels value={pathname}>
+        <BottomNavigation showLabels value={pathWithoutLocale}>
           {ROUTES.map((r) => {
             const Icon = ICONS[r];
-            const route = `${locale}/${ROUTE_NAME_TO_ROUTE[r]}`;
+            const route = ROUTE_NAME_TO_ROUTE[r];
+            const routeWithLocale = `${locale}/${route}`;
 
             return (
               <BottomNavigationAction
                 key={r}
                 label={t(`routes.${r}`)}
                 icon={<Icon />}
-                to={route}
+                to={routeWithLocale}
                 value={route}
                 component={Link}
               />

--- a/src/components/Base.tsx
+++ b/src/components/Base.tsx
@@ -1,4 +1,6 @@
 import { useEffect } from "react";
+import i18n from "i18next";
+import { useTranslation } from "react-i18next";
 import {
   Box,
   Paper,
@@ -6,10 +8,11 @@ import {
   BottomNavigationAction,
 } from "@mui/material";
 import { Home, Info, CorporateFare, QuestionAnswer } from "@mui/icons-material";
-import { Link, Outlet, useLocation } from "react-router-dom";
-import { useTranslation } from "react-i18next";
+import { Link, Outlet, useLocation, useParams } from "react-router-dom";
+import { getLocaleOrFallback, SAVED_LOCALE } from "../locale";
 
 const ROUTES = ["home", "about", "organization", "faq"] as const;
+
 const ICONS = {
   home: Home,
   about: Info,
@@ -18,15 +21,22 @@ const ICONS = {
 } as const;
 
 const ROUTE_NAME_TO_ROUTE = {
-  home: "/",
-  about: "/about",
-  organization: "/organization",
-  faq: "/faq",
+  home: "",
+  about: "about",
+  organization: "organization",
+  faq: "faq",
 } as const;
 
 export const Base = () => {
   const { t } = useTranslation();
   const { pathname } = useLocation();
+  const params = useParams();
+  const locale = getLocaleOrFallback(params.locale as string);
+
+  useEffect(() => {
+    localStorage.setItem(SAVED_LOCALE, locale);
+    i18n.changeLanguage(locale);
+  }, [locale]);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -44,7 +54,7 @@ export const Base = () => {
         <BottomNavigation showLabels value={pathname}>
           {ROUTES.map((r) => {
             const Icon = ICONS[r];
-            const route = ROUTE_NAME_TO_ROUTE[r];
+            const route = `${locale}/${ROUTE_NAME_TO_ROUTE[r]}`;
 
             return (
               <BottomNavigationAction
@@ -57,7 +67,6 @@ export const Base = () => {
               />
             );
           })}
-          =
         </BottomNavigation>
       </Paper>
     </Box>

--- a/src/locale.ts
+++ b/src/locale.ts
@@ -1,5 +1,16 @@
 export const LOCALES = { en: "en", fr: "fr" } as const;
+export const INVERTED_LOCALES = { en: "fr", fr: "en" } as const;
+export const LOCALE_TO_LANGUAGE = { en: "English", fr: "Français" } as const;
 export const DEFAULT_LOCALE = LOCALES.en;
+export const SAVED_LOCALE = "savedLocale";
+
+const SUPPORTED_LOCALES = new Set<string>(Object.values(LOCALES));
+
+export function getLocaleOrFallback(givenLocale: string): "en" | "fr" {
+  return SUPPORTED_LOCALES.has(givenLocale)
+    ? (givenLocale as "en" | "fr")
+    : DEFAULT_LOCALE;
+}
 
 export const resources = {
   [LOCALES.en]: {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,7 +1,13 @@
+import { Link as RouterLink, useParams } from "react-router-dom";
 import { Instagram, FacebookOutlined, Twitter } from "@mui/icons-material";
-import { Box, useTheme } from "@mui/material";
+import { Box, Typography, useTheme } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import { Link } from "../components/Link";
+import {
+  getLocaleOrFallback,
+  INVERTED_LOCALES,
+  LOCALE_TO_LANGUAGE,
+} from "../locale";
 
 const SOCIAL_LINKS = [
   {
@@ -22,6 +28,10 @@ const GAP_PX = `${GAP}px`;
 
 export const Home = () => {
   const theme = useTheme();
+  const params = useParams();
+  const locale = getLocaleOrFallback(params.locale as string);
+
+  const inverseLocale = INVERTED_LOCALES[locale];
 
   const useStyles = makeStyles({
     logo: {
@@ -30,6 +40,14 @@ export const Home = () => {
       [theme.breakpoints.down("sm")]: {
         maxWidth: "75vw",
       },
+    },
+    noTextDecoration: {
+      textDecoration: "none",
+    },
+    verticalLine: {
+      width: "3px",
+      height: "35px",
+      background: "black",
     },
   });
 
@@ -55,6 +73,20 @@ export const Home = () => {
             <Icon fontSize="large" htmlColor="black" />
           </Link>
         ))}
+        <div className={classes.verticalLine} />
+        <RouterLink
+          to={`/${inverseLocale}`}
+          className={classes.noTextDecoration}
+        >
+          <abbr
+            title={LOCALE_TO_LANGUAGE[inverseLocale]}
+            className={classes.noTextDecoration}
+          >
+            <Typography fontSize="24px" fontWeight="bold" color="black">
+              {inverseLocale.toUpperCase()}
+            </Typography>
+          </abbr>
+        </RouterLink>
       </Box>
     </Box>
   );


### PR DESCRIPTION
With the addition of #29, we need to support localization. This is a simple implementation that could be improved upon in the future. Parts of the implementation are dependent on there only being two languages (English and French).

On the home page, there is a link/button to switch language: 

![image](https://user-images.githubusercontent.com/48423418/210013007-560066d8-057c-492c-a46c-9240658f74f3.png)

The user's choice is cached locally. The website's routes now support localization (e.g., `/fr/about`) and the old, non-localized routes (e.g., just `/about`). The user can also change language via the URL.

We always fallback to English if an unsupported locale is supplied in the URL param.








