### PR TITLE
Comp/series page enhancements

### DIFF
--- a/app/src/components/CompetitionCard.tsx
+++ b/app/src/components/CompetitionCard.tsx
@@ -11,6 +11,7 @@ const competitorsApproved = (competition: { data: competition; wcif: wcif }) =>
 export const CompetitionCard = (competition: {
   data: competition;
   wcif: wcif;
+  shouldShowName: boolean;
 }) => {
   const { t } = useTranslation();
 
@@ -27,6 +28,14 @@ export const CompetitionCard = (competition: {
     <Box margin="1rem" padding="1rem" maxWidth="400px">
       <Typography gutterBottom>
         <Trans>
+          {competition.shouldShowName && (
+            <>
+              <Typography component="h1" variant="h5" fontWeight="bold">
+                {competition.data.name}
+              </Typography>
+              <br />
+            </>
+          )}
           {t("competition.date", {
             date: new Date(
               competition.data.start_date + "T00:00:00.000",

--- a/app/src/components/CompetitionHeader.tsx
+++ b/app/src/components/CompetitionHeader.tsx
@@ -31,21 +31,39 @@ export const CompetitionHeader = ({
       <Typography gutterBottom style={{ textAlign: "center" }}>
         <Trans>
           {hasRegistrationOpened
-            ? t("competition.registration.after", { date: registrationOpen })
+            ? t("competition.registration.after", {
+                date: formatDate(registrationOpen),
+              })
             : doSeriesRegistrationsDiffer
             ? t("competition.registration.differentopen", {
-                date: registrationOpen,
+                date: formatDate(registrationOpen),
               })
-            : t("competition.registration.before", { date: registrationOpen })}
+            : t("competition.registration.before", {
+                date: formatDate(registrationOpen),
+              })}
           {hasRegistrationClosed
             ? t("competition.registration.closed", {
-                date: registrationClose,
+                date: formatDate(registrationClose),
               })
             : t("competition.registration.closes", {
-                date: registrationClose,
+                date: formatDate(registrationClose),
               })}
         </Trans>
       </Typography>
     </Box>
   );
 };
+
+/**
+ * Formats a date to the following style: "Thursday, September 12, 2024 at 8:00 PM EDT"
+ */
+const formatDate = (date: Date): string =>
+  date.toLocaleString("en-US", {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+  });

--- a/app/src/helpers/competitionValidator.ts
+++ b/app/src/helpers/competitionValidator.ts
@@ -1,0 +1,8 @@
+import { competition } from "../types";
+
+const SPEEDCUBING_CANADA_USER_ID = "287748";
+
+export const isSpeedcubingCanadaCompetition = (competition: competition) =>
+  competition?.organizers?.some(
+    (o) => o.id.toString() === SPEEDCUBING_CANADA_USER_ID,
+  );

--- a/app/src/pages/Competition.tsx
+++ b/app/src/pages/Competition.tsx
@@ -88,7 +88,7 @@ export const Competition = () => {
           flexWrap="wrap"
           marginTop="2rem"
         >
-          <CompetitionCard {...competitionData} />
+          <CompetitionCard {...competitionData} shouldShowName={false} />
         </Box>
       </Box>
       <Box minHeight="70px">

--- a/app/src/pages/Competition.tsx
+++ b/app/src/pages/Competition.tsx
@@ -6,7 +6,6 @@ import { useState, useEffect } from "react";
 import { CompetitionCard } from "../components/CompetitionCard";
 import { CompetitionHeader } from "../components/CompetitionHeader";
 import { Link } from "../components/Link";
-import { PageNotFound } from "../components/PageNotFound";
 import { LoadingPageLinear } from "../components/LoadingPageLinear";
 import { competition, wcif } from "../types";
 import { isSpeedcubingCanadaCompetition } from "../helpers/competitionValidator";
@@ -19,7 +18,6 @@ export const Competition = () => {
     data: competition;
     wcif: wcif;
   }>(null);
-  const [hasError, setHasError] = useState(false);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -28,7 +26,7 @@ export const Competition = () => {
         fetch(LINKS.WCA.API.COMPETITION_INFO + params.compid).then(
           (response) => {
             if (!response.ok) {
-              setHasError(true);
+              navigate("/", { replace: true });
             }
             return response.json();
           },
@@ -37,7 +35,7 @@ export const Competition = () => {
           LINKS.WCA.API.COMPETITION_INFO + params.compid + "/wcif/public",
         ).then((response) => {
           if (!response.ok) {
-            setHasError(true);
+            navigate("/", { replace: true });
           }
           return response.json();
         }),
@@ -51,10 +49,6 @@ export const Competition = () => {
     };
     getData();
   }, [navigate, params.compid]);
-
-  if (hasError) {
-    return <PageNotFound />;
-  }
 
   if (!competitionData) {
     return <LoadingPageLinear />;

--- a/app/src/pages/Competition.tsx
+++ b/app/src/pages/Competition.tsx
@@ -1,7 +1,7 @@
 import { Box, Container, Typography } from "@mui/material";
 import { Trans, useTranslation } from "react-i18next";
 import { LINKS } from "./links";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { useState, useEffect } from "react";
 import { CompetitionCard } from "../components/CompetitionCard";
 import { CompetitionHeader } from "../components/CompetitionHeader";
@@ -20,6 +20,7 @@ export const Competition = () => {
     wcif: wcif;
   }>(null);
   const [hasError, setHasError] = useState(false);
+  const navigate = useNavigate();
 
   useEffect(() => {
     const getData = async () => {
@@ -43,14 +44,13 @@ export const Competition = () => {
       ]);
 
       if (!isSpeedcubingCanadaCompetition(compData)) {
-        setHasError(true);
-        return;
+        navigate("/", { replace: true });
       }
 
       setCompetitionData({ data: compData, wcif: wcifData });
     };
     getData();
-  }, [params.compid]);
+  }, [navigate, params.compid]);
 
   if (hasError) {
     return <PageNotFound />;

--- a/app/src/pages/Competition.tsx
+++ b/app/src/pages/Competition.tsx
@@ -3,13 +3,13 @@ import { Trans, useTranslation } from "react-i18next";
 import { LINKS } from "./links";
 import { useParams } from "react-router-dom";
 import { useState, useEffect } from "react";
-import { getLocaleOrFallback } from "../locale";
 import { CompetitionCard } from "../components/CompetitionCard";
 import { CompetitionHeader } from "../components/CompetitionHeader";
 import { Link } from "../components/Link";
 import { PageNotFound } from "../components/PageNotFound";
 import { LoadingPageLinear } from "../components/LoadingPageLinear";
 import { competition, wcif } from "../types";
+import { isSpeedcubingCanadaCompetition } from "../helpers/competitionValidator";
 
 export const Competition = () => {
   const { t } = useTranslation();
@@ -41,6 +41,11 @@ export const Competition = () => {
           return response.json();
         }),
       ]);
+
+      if (!isSpeedcubingCanadaCompetition(compData)) {
+        setHasError(true);
+        return;
+      }
 
       setCompetitionData({ data: compData, wcif: wcifData });
     };

--- a/app/src/pages/Series.tsx
+++ b/app/src/pages/Series.tsx
@@ -92,7 +92,11 @@ export const Series = () => {
         >
           {competitionData.map(
             (competition: { data: competition; wcif: wcif }) => (
-              <CompetitionCard {...competition} key={competition.data.id} />
+              <CompetitionCard
+                {...competition}
+                key={competition.data.id}
+                shouldShowName
+              />
             ),
           )}
         </Box>

--- a/app/src/pages/Series.tsx
+++ b/app/src/pages/Series.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect } from "react";
 import { LINKS } from "./links";
 import { CompetitionCard } from "../components/CompetitionCard";
 import { CompetitionHeader } from "../components/CompetitionHeader";
-import { PageNotFound } from "../components/PageNotFound";
 import { LoadingPageLinear } from "../components/LoadingPageLinear";
 import { useTranslation } from "react-i18next";
 import { competition, wcif } from "../types";
@@ -17,7 +16,6 @@ export const Series = () => {
   const [competitionData, setCompetitionData] = useState<
     null | { data: competition; wcif: wcif }[]
   >(null);
-  const [hasError, setHasError] = useState(false);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -26,8 +24,7 @@ export const Series = () => {
       const seriesCompetitions = await response.json();
 
       if (!response.ok) {
-        setHasError(true);
-        return;
+        navigate("/", { replace: true });
       }
 
       const allData = await Promise.all(
@@ -53,10 +50,6 @@ export const Series = () => {
     };
     getData(seriesid!);
   }, [navigate, seriesid]);
-
-  if (hasError) {
-    return <PageNotFound />;
-  }
 
   if (!competitionData) {
     return <LoadingPageLinear />;

--- a/app/src/pages/Series.tsx
+++ b/app/src/pages/Series.tsx
@@ -8,6 +8,7 @@ import { PageNotFound } from "../components/PageNotFound";
 import { LoadingPageLinear } from "../components/LoadingPageLinear";
 import { useTranslation } from "react-i18next";
 import { competition, wcif } from "../types";
+import { isSpeedcubingCanadaCompetition } from "../helpers/competitionValidator";
 
 export const Series = () => {
   const { t } = useTranslation();
@@ -28,7 +29,7 @@ export const Series = () => {
         return;
       }
 
-      let allData = await Promise.all(
+      const allData = await Promise.all(
         seriesCompetitions.competitionIds.map(async (key: string) => {
           const competitionData = await (
             await fetch(LINKS.WCA.API.COMPETITION_INFO + key)
@@ -39,6 +40,14 @@ export const Series = () => {
           return { data: competitionData, wcif: wcifData };
         }),
       );
+
+      if (
+        allData.length === 0 ||
+        !isSpeedcubingCanadaCompetition(allData[0].data)
+      ) {
+        setHasError(true);
+        return;
+      }
 
       setCompetitionData(allData);
     };

--- a/app/src/pages/Series.tsx
+++ b/app/src/pages/Series.tsx
@@ -1,5 +1,5 @@
 import { Box, Container, Typography } from "@mui/material";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { useState, useEffect } from "react";
 import { LINKS } from "./links";
 import { CompetitionCard } from "../components/CompetitionCard";
@@ -18,6 +18,7 @@ export const Series = () => {
     null | { data: competition; wcif: wcif }[]
   >(null);
   const [hasError, setHasError] = useState(false);
+  const navigate = useNavigate();
 
   useEffect(() => {
     const getData = async (seriesId: string) => {
@@ -45,14 +46,13 @@ export const Series = () => {
         allData.length === 0 ||
         !isSpeedcubingCanadaCompetition(allData[0].data)
       ) {
-        setHasError(true);
-        return;
+        navigate("/", { replace: true });
       }
 
       setCompetitionData(allData);
     };
     getData(seriesid!);
-  }, [seriesid]);
+  }, [navigate, seriesid]);
 
   if (hasError) {
     return <PageNotFound />;

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -9,6 +9,7 @@ export type competition = {
   venue_address: string;
   url: string;
   start_date: string;
+  organizers: Array<{ id: number }>;
 };
 
 export type wcif = {


### PR DESCRIPTION
See commits. This makes the website's behaviour consistent with the general 404 case if you tried to visit `/en/foo/bar`, for example. The functional changes include adding the comp names to the series pages (as per @AlyssaHope's request) and having the comp and series pages redirect home instead of rendering if Speedcubing Canada is not a listed organizer.