### PR TITLE
Fix issues with navbar not closing, fix double fetch

### DIFF
--- a/app/src/components/Base.tsx
+++ b/app/src/components/Base.tsx
@@ -26,8 +26,15 @@ import {
   AccountCircle,
   Leaderboard,
 } from "@mui/icons-material";
+import { flushSync } from "react-dom";
 
-import { Link, Outlet, useLocation, useParams } from "react-router-dom";
+import {
+  Link,
+  Outlet,
+  useLocation,
+  useParams,
+  useNavigate,
+} from "react-router-dom";
 import { getLocaleOrFallback, SAVED_LOCALE } from "../locale";
 import { useScrollbarWidth } from "../helpers/scrollbarWidth";
 import { useBodyScrollable } from "../helpers/useBodyScrollable";
@@ -79,6 +86,7 @@ export const Base = () => {
   const locale = getLocaleOrFallback(params.locale as string);
   const theme = useTheme();
   const isSmall = useMediaQuery<Theme>((theme) => theme.breakpoints.down("sm"));
+  const navigate = useNavigate();
 
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
@@ -90,6 +98,10 @@ export const Base = () => {
   useEffect(() => {
     window.scrollTo(0, 0);
   }, [pathWithoutLocale]);
+
+  useEffect(() => {
+    setIsDrawerOpen(false);
+  }, [pathname]);
 
   const navigationBarItems: NavigationBarItem[] = ROUTE_NAMES.map(
     (routeName) => {
@@ -108,80 +120,98 @@ export const Base = () => {
   const scrollbarWidth = useScrollbarWidth();
   const paddingWidth = bodyScrollable ? 0 : scrollbarWidth;
 
-  return isSmall ? (
-    <Box minHeight="90vh" flex={1} display="flex" flexDirection="column">
-      <Paper sx={{ position: "sticky", top: 0, zIndex: 1100 }} elevation={2}>
-        <IconButton onClick={() => setIsDrawerOpen(true)}>
-          <Menu sx={{ fontSize: 40, color: "black" }} />
-        </IconButton>
-      </Paper>
-      <Drawer
-        open={isDrawerOpen}
-        anchor="left"
-        onClose={() => setIsDrawerOpen(false)}
-      >
-        <List>
-          {navigationBarItems.map(
-            ({ routeName, Icon, path, pathWithLocale }) => {
-              const color =
-                pathWithoutLocale === path
-                  ? theme.palette.primary.main
-                  : undefined;
+  return (
+    <Box
+      minHeight={isSmall ? "90vh" : "100vh"}
+      flex={1}
+      display="flex"
+      flexDirection="column"
+    >
+      {isSmall && (
+        <>
+          <Paper
+            sx={{ position: "sticky", top: 0, zIndex: 1100 }}
+            elevation={2}
+          >
+            <IconButton onClick={() => setIsDrawerOpen(true)}>
+              <Menu sx={{ fontSize: 40, color: "black" }} />
+            </IconButton>
+          </Paper>
+          <Drawer
+            open={isDrawerOpen}
+            anchor="left"
+            onClose={() => setIsDrawerOpen(false)}
+          >
+            <List>
+              {navigationBarItems.map(
+                ({ routeName, Icon, path, pathWithLocale }) => {
+                  const color =
+                    pathWithoutLocale === path
+                      ? theme.palette.primary.main
+                      : undefined;
 
-              return (
-                <ListItemButton
+                  return (
+                    <ListItemButton
+                      key={routeName}
+                      component={Link}
+                      to={pathWithLocale}
+                      onClick={() => {
+                        if (pathWithoutLocale === path) {
+                          setIsDrawerOpen(false);
+                        }
+                      }}
+                    >
+                      <ListItemIcon sx={{ color }}>
+                        <Icon />
+                      </ListItemIcon>
+                      <ListItemText
+                        primary={t(`routes.${routeName}`)}
+                        sx={{ color }}
+                      />
+                    </ListItemButton>
+                  );
+                },
+              )}
+            </List>
+          </Drawer>
+        </>
+      )}
+      <Box display="flex" flex={1}>
+        <Outlet />
+      </Box>
+      {!isSmall && (
+        <Paper
+          sx={{
+            position: "sticky",
+            bottom: 0,
+            left: 0,
+            right: 0,
+            zIndex: 1100,
+          }}
+          elevation={2}
+        >
+          <BottomNavigation
+            showLabels
+            value={pathWithoutLocale}
+            sx={{
+              paddingRight: `${paddingWidth}px`,
+            }}
+          >
+            {navigationBarItems.map(
+              ({ routeName, Icon, path, pathWithLocale }) => (
+                <BottomNavigationAction
                   key={routeName}
+                  label={t(`routes.${routeName}`)}
                   component={Link}
                   to={pathWithLocale}
-                  onClick={() => setIsDrawerOpen(false)}
-                >
-                  <ListItemIcon sx={{ color }}>
-                    <Icon />
-                  </ListItemIcon>
-                  <ListItemText
-                    primary={t(`routes.${routeName}`)}
-                    sx={{ color }}
-                  />
-                </ListItemButton>
-              );
-            },
-          )}
-        </List>
-      </Drawer>
-      <Box display="flex" flex={1}>
-        <Outlet />
-      </Box>
-    </Box>
-  ) : (
-    <Box minHeight="100vh" flex={1} display="flex" flexDirection="column">
-      <Box display="flex" flex={1}>
-        <Outlet />
-      </Box>
-      <Paper
-        sx={{ position: "sticky", bottom: 0, left: 0, right: 0, zIndex: 1100 }}
-        elevation={2}
-      >
-        <BottomNavigation
-          showLabels
-          value={pathWithoutLocale}
-          sx={{
-            paddingRight: `${paddingWidth}px`,
-          }}
-        >
-          {navigationBarItems.map(
-            ({ routeName, Icon, path, pathWithLocale }) => (
-              <BottomNavigationAction
-                key={routeName}
-                label={t(`routes.${routeName}`)}
-                component={Link}
-                to={pathWithLocale}
-                icon={<Icon />}
-                value={path}
-              />
-            ),
-          )}
-        </BottomNavigation>
-      </Paper>
+                  icon={<Icon />}
+                  value={path}
+                />
+              ),
+            )}
+          </BottomNavigation>
+        </Paper>
+      )}
     </Box>
   );
 };

--- a/app/src/components/Base.tsx
+++ b/app/src/components/Base.tsx
@@ -26,15 +26,8 @@ import {
   AccountCircle,
   Leaderboard,
 } from "@mui/icons-material";
-import { flushSync } from "react-dom";
 
-import {
-  Link,
-  Outlet,
-  useLocation,
-  useParams,
-  useNavigate,
-} from "react-router-dom";
+import { Link, Outlet, useLocation, useParams } from "react-router-dom";
 import { getLocaleOrFallback, SAVED_LOCALE } from "../locale";
 import { useScrollbarWidth } from "../helpers/scrollbarWidth";
 import { useBodyScrollable } from "../helpers/useBodyScrollable";
@@ -86,7 +79,6 @@ export const Base = () => {
   const locale = getLocaleOrFallback(params.locale as string);
   const theme = useTheme();
   const isSmall = useMediaQuery<Theme>((theme) => theme.breakpoints.down("sm"));
-  const navigate = useNavigate();
 
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 


### PR DESCRIPTION
This fixes the issue of the mobile navbar not closing by decoupling the page change event with the navigation event. 

I beleive this is due to React's batch UI update hander, and that it handles these in a non-deterministic way. If the request to close the navbar occours after the UI is torn down due to the navigation, and a new Drawer component is built, then it doesnt do anything, and the new drawer stays open. By modifying it like this, we will create a new useState, whch is attached to the new Drawer after the navigation, and then tell it to close.

The double API fetch was caused by the Base component having two copies of the Outlet component in the ternary, which led to a full re-render fo the page whenever the threshold was passed.