### PR TITLE
Adding a CI/CD pipeline

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -29,24 +29,38 @@ deploy-production               (./deploy.sh -p)
 
 ---
 
-## 1. Create GCP service accounts
+## Authentication — Workload Identity Federation
 
-The pipeline uses **two separate service accounts** — one per environment — so
-that a compromised staging credential cannot be used to push to production.
+The pipeline authenticates to GCP using **Workload Identity Federation (WIF)**
+rather than long-lived JSON key files. GitHub Actions presents a short-lived
+OIDC token; GCP verifies it and issues temporary credentials scoped to a
+specific service account. No secrets are stored in GitHub.
 
-### Staging service account
+There are four steps per GCP project: create the service account, grant it
+deployment roles, create a WIF pool + provider, then allow the pool to
+impersonate the service account.
+
+### Variables used in the commands below
+
+```bash
+REPO="Speedcubing-Canada/speedcubing-canada-web"
+```
+
+---
+
+### Staging project
+
+```bash
+PROJECT="scc-staging-391105"
+SA="github-actions-staging@${PROJECT}.iam.gserviceaccount.com"
+```
+
+**1. Create the service account and grant deployment roles**
 
 ```bash
 gcloud iam service-accounts create github-actions-staging \
   --display-name "GitHub Actions – Staging" \
-  --project scc-staging-391105
-```
-
-Grant the roles it needs to deploy App Engine services:
-
-```bash
-SA="github-actions-staging@scc-staging-391105.iam.gserviceaccount.com"
-PROJECT="scc-staging-391105"
+  --project "${PROJECT}"
 
 for role in \
   roles/appengine.deployer \
@@ -54,9 +68,9 @@ for role in \
   roles/cloudbuild.builds.editor \
   roles/storage.admin \
   roles/iam.serviceAccountUser; do
-  gcloud projects add-iam-policy-binding "$PROJECT" \
+  gcloud projects add-iam-policy-binding "${PROJECT}" \
     --member="serviceAccount:${SA}" \
-    --role="$role"
+    --role="${role}"
 done
 ```
 
@@ -64,26 +78,65 @@ done
 > internally submits a Cloud Build job that runs as the App Engine default
 > service account; your SA must be allowed to impersonate it.
 
-Generate and download the JSON key:
+**2. Create the Workload Identity Pool and provider**
 
 ```bash
-gcloud iam service-accounts keys create staging-sa-key.json \
-  --iam-account "$SA" \
-  --project "$PROJECT"
+gcloud iam workload-identity-pools create "github-actions" \
+  --project="${PROJECT}" \
+  --location="global" \
+  --display-name="GitHub Actions"
+
+gcloud iam workload-identity-pools providers create-oidc "github" \
+  --project="${PROJECT}" \
+  --location="global" \
+  --workload-identity-pool="github-actions" \
+  --display-name="GitHub" \
+  --issuer-uri="https://token.actions.githubusercontent.com" \
+  --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository" \
+  --attribute-condition="assertion.repository=='${REPO}'"
 ```
 
-### Production service account
+The `attribute-condition` locks the provider to this repository only — tokens
+from any other repo are rejected by GCP before they reach the service account.
 
-Repeat the same steps for the production project, substituting
-`scc-production-398617`:
+**3. Allow the pool to impersonate the staging SA**
 
 ```bash
+POOL=$(gcloud iam workload-identity-pools describe "github-actions" \
+  --project="${PROJECT}" \
+  --location="global" \
+  --format="value(name)")
+
+gcloud iam service-accounts add-iam-policy-binding "${SA}" \
+  --project="${PROJECT}" \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="principalSet://iam.googleapis.com/${POOL}/attribute.repository/${REPO}"
+```
+
+**4. Note the provider resource name** (you'll need it in step 3 below)
+
+```bash
+gcloud iam workload-identity-pools providers describe "github" \
+  --project="${PROJECT}" \
+  --location="global" \
+  --workload-identity-pool="github-actions" \
+  --format="value(name)"
+# → projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/github-actions/providers/github
+```
+
+---
+
+### Production project
+
+Repeat the same four steps for the production project:
+
+```bash
+PROJECT="scc-production-398617"
+SA="github-actions-prod@${PROJECT}.iam.gserviceaccount.com"
+
 gcloud iam service-accounts create github-actions-prod \
   --display-name "GitHub Actions – Production" \
-  --project scc-production-398617
-
-SA="github-actions-prod@scc-production-398617.iam.gserviceaccount.com"
-PROJECT="scc-production-398617"
+  --project "${PROJECT}"
 
 for role in \
   roles/appengine.deployer \
@@ -91,33 +144,57 @@ for role in \
   roles/cloudbuild.builds.editor \
   roles/storage.admin \
   roles/iam.serviceAccountUser; do
-  gcloud projects add-iam-policy-binding "$PROJECT" \
+  gcloud projects add-iam-policy-binding "${PROJECT}" \
     --member="serviceAccount:${SA}" \
-    --role="$role"
+    --role="${role}"
 done
 
-gcloud iam service-accounts keys create prod-sa-key.json \
-  --iam-account "$SA" \
-  --project "$PROJECT"
+gcloud iam workload-identity-pools create "github-actions" \
+  --project="${PROJECT}" \
+  --location="global" \
+  --display-name="GitHub Actions"
+
+gcloud iam workload-identity-pools providers create-oidc "github" \
+  --project="${PROJECT}" \
+  --location="global" \
+  --workload-identity-pool="github-actions" \
+  --display-name="GitHub" \
+  --issuer-uri="https://token.actions.githubusercontent.com" \
+  --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository" \
+  --attribute-condition="assertion.repository=='${REPO}'"
+
+POOL=$(gcloud iam workload-identity-pools describe "github-actions" \
+  --project="${PROJECT}" \
+  --location="global" \
+  --format="value(name)")
+
+gcloud iam service-accounts add-iam-policy-binding "${SA}" \
+  --project="${PROJECT}" \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="principalSet://iam.googleapis.com/${POOL}/attribute.repository/${REPO}"
+
+gcloud iam workload-identity-pools providers describe "github" \
+  --project="${PROJECT}" \
+  --location="global" \
+  --workload-identity-pool="github-actions" \
+  --format="value(name)"
+# → projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/github-actions/providers/github
 ```
 
 ---
 
-## 2. Add secrets to the GitHub repository
+## 2. Add repository variables to GitHub
 
-Go to **Settings → Secrets and variables → Actions → New repository secret**
-and add the following two secrets.
+Go to **Settings → Secrets and variables → Actions → Variables tab → New repository variable**
+and add the following four variables. These are not secrets — WIF provider
+names and service account emails are not sensitive.
 
-| Secret name          | Value                                  |
-| -------------------- | -------------------------------------- |
-| `GCP_SA_KEY_STAGING` | Full contents of `staging-sa-key.json` |
-| `GCP_SA_KEY_PROD`    | Full contents of `prod-sa-key.json`    |
-
-Delete the local key files after uploading:
-
-```bash
-rm staging-sa-key.json prod-sa-key.json
-```
+| Variable name          | Value                                                               |
+| ---------------------- | ------------------------------------------------------------------- |
+| `WIF_PROVIDER_STAGING` | Provider resource name from the staging `describe` command above    |
+| `WIF_SA_STAGING`       | `github-actions-staging@scc-staging-391105.iam.gserviceaccount.com` |
+| `WIF_PROVIDER_PROD`    | Provider resource name from the production `describe` command above |
+| `WIF_SA_PROD`          | `github-actions-prod@scc-production-398617.iam.gserviceaccount.com` |
 
 ---
 
@@ -149,7 +226,7 @@ Clean them up periodically:
 # List all staging versions
 gcloud app versions list --project scc-staging-391105
 
-# Delete a specific version (frontend + API service)
+# Delete a specific version (repeat for each service)
 gcloud app versions delete ci-abc12345 \
   --project scc-staging-391105 \
   --service default
@@ -161,11 +238,16 @@ gcloud app versions delete ci-abc12345 \
 
 ---
 
-## Optional: Workload Identity Federation (passwordless auth)
+## Manual deploys
 
-The workflow above uses long-lived JSON key files. For higher security,
-[Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation)
-lets GitHub Actions authenticate without any stored credentials. If you migrate
-to WIF, replace the `credentials_json` input in `deploy.yml` with
-`workload_identity_provider` and `service_account` parameters as described in
-the [`google-github-actions/auth` README](https://github.com/google-github-actions/auth).
+The `deploy.sh` script at the repo root is unchanged and can still be used
+for one-off manual deployments. It requires `gcloud` to be authenticated
+locally (e.g. via `gcloud auth login` or `gcloud auth application-default login`):
+
+```bash
+# Staging
+./deploy.sh -s -v my-test-version
+
+# Production
+./deploy.sh -p
+```

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -20,11 +20,16 @@ smoke-test (two steps)
   └─ api       GET https://api.staging.speedcubingcanada.org/test_rankings
     │           Flask returns hardcoded JSON (province_rankings.py, no DB/auth) → expect 2xx
     │
-    ▼ (blocks here if either check fails)
-[manual approval]               (GitHub Environment: production)
-    │
-    ▼
-deploy-production               (./deploy.sh -p)
+    ├─────────────────────────────────┐
+    ▼                                 ▼
+cleanup-staging                 [manual approval]       (GitHub Environment: production)
+(keep 5 newest, both services)        │
+                                      ▼
+                                deploy-production       (./deploy.sh -p)
+                                      │
+                                      ▼
+                                cleanup-production
+                                (keep 5 newest, both services)
 ```
 
 ---
@@ -216,24 +221,30 @@ GitHub notification and can approve or reject from the Actions run page.
 
 ---
 
-## Staging version cleanup
+## Version cleanup
 
-Each CI run deploys a uniquely versioned staging version
-(`ci-<8-char-sha>`). Old versions accumulate and incur small storage costs.
-Clean them up periodically:
+Cleanup is automated by the pipeline: after every successful staging smoke test
+and every production deploy, a cleanup job runs and deletes all but the 5 most
+recent versions of each App Engine service (`default` and `api`). The job is
+marked `continue-on-error` so a cleanup failure never blocks the pipeline.
+
+**5 versions** gives you enough rollback history without significant storage
+cost. If you want to adjust the number, change the `KEEP` env var in the two
+cleanup jobs in `deploy.yml`.
+
+If you ever need to clean up manually (e.g. after a failed pipeline left
+orphaned versions):
 
 ```bash
-# List all staging versions
-gcloud app versions list --project scc-staging-391105
+# List versions for a project / service
+gcloud app versions list --project scc-staging-391105 --service default
+gcloud app versions list --project scc-staging-391105 --service api
 
-# Delete a specific version (repeat for each service)
+# Delete a specific version
 gcloud app versions delete ci-abc12345 \
-  --project scc-staging-391105 \
-  --service default
-
+  --project scc-staging-391105 --service default --quiet
 gcloud app versions delete ci-abc12345 \
-  --project scc-staging-391105 \
-  --service api
+  --project scc-staging-391105 --service api --quiet
 ```
 
 ---

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,171 @@
+# Deployment Pipeline — Setup Guide
+
+This document explains the one-time setup required before the
+[`deploy.yml`](deploy.yml) workflow can run successfully.
+
+---
+
+## Pipeline overview
+
+```
+push to main
+    │
+    ▼
+deploy-staging                  (./deploy.sh -s -v ci-<sha>)
+    │
+    ▼
+smoke-test (two steps)
+  ├─ frontend  GET https://staging.speedcubingcanada.org/
+  │            Express serves dist/index.html → expect 2xx
+  └─ api       GET https://api.staging.speedcubingcanada.org/test_rankings
+    │           Flask returns hardcoded JSON (province_rankings.py, no DB/auth) → expect 2xx
+    │
+    ▼ (blocks here if either check fails)
+[manual approval]               (GitHub Environment: production)
+    │
+    ▼
+deploy-production               (./deploy.sh -p)
+```
+
+---
+
+## 1. Create GCP service accounts
+
+The pipeline uses **two separate service accounts** — one per environment — so
+that a compromised staging credential cannot be used to push to production.
+
+### Staging service account
+
+```bash
+gcloud iam service-accounts create github-actions-staging \
+  --display-name "GitHub Actions – Staging" \
+  --project scc-staging-391105
+```
+
+Grant the roles it needs to deploy App Engine services:
+
+```bash
+SA="github-actions-staging@scc-staging-391105.iam.gserviceaccount.com"
+PROJECT="scc-staging-391105"
+
+for role in \
+  roles/appengine.deployer \
+  roles/appengine.serviceAdmin \
+  roles/cloudbuild.builds.editor \
+  roles/storage.admin \
+  roles/iam.serviceAccountUser; do
+  gcloud projects add-iam-policy-binding "$PROJECT" \
+    --member="serviceAccount:${SA}" \
+    --role="$role"
+done
+```
+
+> **`roles/iam.serviceAccountUser`** is required because `gcloud app deploy`
+> internally submits a Cloud Build job that runs as the App Engine default
+> service account; your SA must be allowed to impersonate it.
+
+Generate and download the JSON key:
+
+```bash
+gcloud iam service-accounts keys create staging-sa-key.json \
+  --iam-account "$SA" \
+  --project "$PROJECT"
+```
+
+### Production service account
+
+Repeat the same steps for the production project, substituting
+`scc-production-398617`:
+
+```bash
+gcloud iam service-accounts create github-actions-prod \
+  --display-name "GitHub Actions – Production" \
+  --project scc-production-398617
+
+SA="github-actions-prod@scc-production-398617.iam.gserviceaccount.com"
+PROJECT="scc-production-398617"
+
+for role in \
+  roles/appengine.deployer \
+  roles/appengine.serviceAdmin \
+  roles/cloudbuild.builds.editor \
+  roles/storage.admin \
+  roles/iam.serviceAccountUser; do
+  gcloud projects add-iam-policy-binding "$PROJECT" \
+    --member="serviceAccount:${SA}" \
+    --role="$role"
+done
+
+gcloud iam service-accounts keys create prod-sa-key.json \
+  --iam-account "$SA" \
+  --project "$PROJECT"
+```
+
+---
+
+## 2. Add secrets to the GitHub repository
+
+Go to **Settings → Secrets and variables → Actions → New repository secret**
+and add the following two secrets.
+
+| Secret name          | Value                                  |
+| -------------------- | -------------------------------------- |
+| `GCP_SA_KEY_STAGING` | Full contents of `staging-sa-key.json` |
+| `GCP_SA_KEY_PROD`    | Full contents of `prod-sa-key.json`    |
+
+Delete the local key files after uploading:
+
+```bash
+rm staging-sa-key.json prod-sa-key.json
+```
+
+---
+
+## 3. Create the `production` environment with required reviewers
+
+The `deploy-production` job references `environment: production`. GitHub will
+pause that job and send a review request to the configured reviewers.
+
+1. Go to **Settings → Environments → New environment**.
+2. Name it exactly **`production`** (case-sensitive).
+3. Under **Deployment protection rules**, enable **Required reviewers** and add
+   at least one GitHub user or team.
+4. Optionally enable **Deployment branches** → **Selected branches** → add
+   `main` to prevent accidental production deploys from feature branches.
+5. Save the environment.
+
+When a push to `main` reaches the production job, reviewers will receive a
+GitHub notification and can approve or reject from the Actions run page.
+
+---
+
+## Staging version cleanup
+
+Each CI run deploys a uniquely versioned staging version
+(`ci-<8-char-sha>`). Old versions accumulate and incur small storage costs.
+Clean them up periodically:
+
+```bash
+# List all staging versions
+gcloud app versions list --project scc-staging-391105
+
+# Delete a specific version (frontend + API service)
+gcloud app versions delete ci-abc12345 \
+  --project scc-staging-391105 \
+  --service default
+
+gcloud app versions delete ci-abc12345 \
+  --project scc-staging-391105 \
+  --service api
+```
+
+---
+
+## Optional: Workload Identity Federation (passwordless auth)
+
+The workflow above uses long-lived JSON key files. For higher security,
+[Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation)
+lets GitHub Actions authenticate without any stored credentials. If you migrate
+to WIF, replace the `credentials_json` input in `deploy.yml` with
+`workload_identity_provider` and `service_account` parameters as described in
+the [`google-github-actions/auth` README](https://github.com/google-github-actions/auth).

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,11 @@
 # Deployment pipeline: staging → smoke test → production (manual gate)
 #
 # Triggered on every push to main (including Dependabot merges).
-# Secrets required:
-#   GCP_SA_KEY_STAGING  – service account JSON key for scc-staging-391105
-#   GCP_SA_KEY_PROD     – service account JSON key for scc-production-398617
+# Repository variables required (Settings → Secrets and variables → Variables):
+#   WIF_PROVIDER_STAGING  – Workload Identity provider resource name (staging)
+#   WIF_PROVIDER_PROD     – Workload Identity provider resource name (prod)
+#   WIF_SA_STAGING        – Service account email for staging deploys
+#   WIF_SA_PROD           – Service account email for production deploys
 # See .github/workflows/README.md for setup instructions.
 
 name: Deploy
@@ -44,7 +46,8 @@ jobs:
       - name: Authenticate to Google Cloud (staging SA)
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY_STAGING }}
+          workload_identity_provider: ${{ vars.WIF_PROVIDER_STAGING }}
+          service_account: ${{ vars.WIF_SA_STAGING }}
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
@@ -148,7 +151,8 @@ jobs:
       - name: Authenticate to Google Cloud (production SA)
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY_PROD }}
+          workload_identity_provider: ${{ vars.WIF_PROVIDER_PROD }}
+          service_account: ${{ vars.WIF_SA_PROD }}
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,9 @@
 
 name: Deploy
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,157 @@
+# Deployment pipeline: staging → smoke test → production (manual gate)
+#
+# Triggered on every push to main (including Dependabot merges).
+# Secrets required:
+#   GCP_SA_KEY_STAGING  – service account JSON key for scc-staging-391105
+#   GCP_SA_KEY_PROD     – service account JSON key for scc-production-398617
+# See .github/workflows/README.md for setup instructions.
+
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  # ── 1. Deploy to staging ──────────────────────────────────────────────────
+  deploy-staging:
+    name: Deploy → Staging
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.slug.outputs.version }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # App Engine version names must be lowercase letters, digits, or hyphens
+      # and start with a letter. "ci-<8-char-sha>" satisfies all constraints.
+      - name: Compute version slug
+        id: slug
+        run: echo "version=ci-${GITHUB_SHA::8}" >> "$GITHUB_OUTPUT"
+
+      # deploy.sh builds the frontend locally before uploading.
+      # The App Engine runtime (nodejs24) and the devDependencies agree on
+      # Node 24, so use the same version here for build consistency.
+      - name: Set up Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Install frontend dependencies
+        run: npm install
+        working-directory: front
+
+      - name: Authenticate to Google Cloud (staging SA)
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY_STAGING }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Deploy to staging
+        run: ./deploy.sh -s -v "${{ steps.slug.outputs.version }}"
+
+  # ── 2. Smoke test against the freshly deployed staging version ────────────
+  #
+  # Two checks are run independently so a failure message names the culprit:
+  #
+  #  Frontend  GET /   → Express (server.js) serves index.html from dist/.
+  #                      Confirms the Node runtime started and the Vite build
+  #                      was uploaded correctly.
+  #
+  #  API       GET /test_rankings
+  #                    → Flask returns hardcoded ranking JSON (province_rankings.py:13).
+  #                      No database or auth required, so this is a pure liveness
+  #                      check: gunicorn started, the app initialised, and the
+  #                      blueprint was registered.
+  #
+  # Checks run against the live staging domain so they exercise the full
+  # request path including dispatch rules and the custom domain certificate.
+  smoke-test:
+    name: Smoke Test (staging)
+    needs: deploy-staging
+    runs-on: ubuntu-latest
+
+    steps:
+      # App Engine versions can take a few seconds to serve traffic after the
+      # deploy command returns. Give the runtime a moment before probing.
+      - name: Wait for App Engine warm-up
+        run: sleep 15
+
+      - name: Smoke test — frontend (GET /)
+        run: |
+          url="https://staging.speedcubingcanada.org/"
+          echo "Probing frontend: ${url}"
+
+          for attempt in 1 2 3; do
+            status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 "${url}")
+            if [ "${status}" -ge 200 ] && [ "${status}" -lt 400 ]; then
+              echo "Frontend OK — HTTP ${status} (attempt ${attempt})"
+              exit 0
+            fi
+            echo "HTTP ${status} (attempt ${attempt}/3); retrying in 15 s…"
+            sleep 15
+          done
+
+          echo "::error::Frontend smoke test failed — GET ${url} never returned 2xx/3xx"
+          exit 1
+
+      - name: Smoke test — API (GET /test_rankings)
+        run: |
+          url="https://api.staging.speedcubingcanada.org/test_rankings"
+          echo "Probing API: ${url}"
+
+          for attempt in 1 2 3; do
+            body=$(curl -s --max-time 30 -w "\n%{http_code}" "${url}")
+            status=$(echo "${body}" | tail -1)
+            if [ "${status}" -ge 200 ] && [ "${status}" -lt 400 ]; then
+              echo "API OK — HTTP ${status} (attempt ${attempt})"
+              # Sanity-check that the response looks like the expected JSON array.
+              if echo "${body}" | head -1 | grep -q '"name"'; then
+                echo "Response body contains expected ranking data."
+              else
+                echo "::warning::Response did not contain expected JSON shape — check /test_rankings output."
+              fi
+              exit 0
+            fi
+            echo "HTTP ${status} (attempt ${attempt}/3); retrying in 15 s…"
+            sleep 15
+          done
+
+          echo "::error::API smoke test failed — GET ${url} never returned 2xx/3xx"
+          exit 1
+
+  # ── 3. Production deploy (gated behind manual approval) ───────────────────
+  #
+  # The 'production' GitHub environment must have required reviewers configured.
+  # This job blocks until a reviewer approves from the Actions UI.
+  # See .github/workflows/README.md → "Create the production environment".
+  deploy-production:
+    name: Deploy → Production
+    needs: smoke-test # only runs if smoke test passed
+    runs-on: ubuntu-latest
+    environment: production # pauses here for manual approval
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Install frontend dependencies
+        run: npm install
+        working-directory: front
+
+      - name: Authenticate to Google Cloud (production SA)
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY_PROD }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Deploy to production
+        run: ./deploy.sh -p

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,11 @@ on:
   push:
     branches: [main]
 
+# WIF authentication requires permission to mint a short-lived OIDC token.
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   # ── 1. Deploy to staging ──────────────────────────────────────────────────
   deploy-staging:
@@ -159,3 +164,109 @@ jobs:
 
       - name: Deploy to production
         run: ./deploy.sh -p
+
+  # ── 4. Clean up old staging versions ─────────────────────────────────────
+  # Runs after a successful smoke test, in parallel with the approval wait,
+  # keeping only the 5 most recent versions of each App Engine service.
+  # continue-on-error ensures a cleanup failure never blocks production.
+  cleanup-staging:
+    name: Cleanup old staging versions
+    needs: smoke-test
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - name: Authenticate to Google Cloud (staging SA)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.WIF_PROVIDER_STAGING }}
+          service_account: ${{ vars.WIF_SA_STAGING }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Delete old staging versions (keep newest 5)
+        env:
+          PROJECT: scc-staging-391105
+          KEEP: "5"
+        run: |
+          for service in default api; do
+            echo "=== ${service} service ==="
+
+            all=$(gcloud app versions list \
+              --project="${PROJECT}" \
+              --service="${service}" \
+              --sort-by="~version.createTime" \
+              --format="value(version.id)" 2>/dev/null || true)
+
+            [ -z "${all}" ] && echo "  No versions found — skipping" && continue
+
+            to_delete=$(echo "${all}" | tail -n +$((KEEP + 1)))
+
+            [ -z "${to_delete}" ] && \
+              echo "  $(echo "${all}" | wc -l | tr -d ' ') version(s) present — nothing to remove" && \
+              continue
+
+            echo "  Removing: $(echo "${to_delete}" | tr '\n' ' ')"
+            while IFS= read -r v; do
+              gcloud app versions delete "${v}" \
+                --project="${PROJECT}" \
+                --service="${service}" \
+                --quiet \
+                && echo "  ✓ deleted ${v}" \
+                || echo "  ✗ could not delete ${v} (skipping)"
+            done <<< "${to_delete}"
+          done
+
+  # ── 5. Clean up old production versions ──────────────────────────────────
+  # Same logic as cleanup-staging but for the production project.
+  # Production versions are auto-named by gcloud (timestamp-based) since
+  # deploy.sh -p does not pass --version.
+  cleanup-production:
+    name: Cleanup old production versions
+    needs: deploy-production
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - name: Authenticate to Google Cloud (production SA)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.WIF_PROVIDER_PROD }}
+          service_account: ${{ vars.WIF_SA_PROD }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Delete old production versions (keep newest 5)
+        env:
+          PROJECT: scc-production-398617
+          KEEP: "5"
+        run: |
+          for service in default api; do
+            echo "=== ${service} service ==="
+
+            all=$(gcloud app versions list \
+              --project="${PROJECT}" \
+              --service="${service}" \
+              --sort-by="~version.createTime" \
+              --format="value(version.id)" 2>/dev/null || true)
+
+            [ -z "${all}" ] && echo "  No versions found — skipping" && continue
+
+            to_delete=$(echo "${all}" | tail -n +$((KEEP + 1)))
+
+            [ -z "${to_delete}" ] && \
+              echo "  $(echo "${all}" | wc -l | tr -d ' ') version(s) present — nothing to remove" && \
+              continue
+
+            echo "  Removing: $(echo "${to_delete}" | tr '\n' ' ')"
+            while IFS= read -r v; do
+              gcloud app versions delete "${v}" \
+                --project="${PROJECT}" \
+                --service="${service}" \
+                --quiet \
+                && echo "  ✓ deleted ${v}" \
+                || echo "  ✗ could not delete ${v} (skipping)"
+            done <<< "${to_delete}"
+          done

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,9 +10,6 @@
 
 name: Deploy
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 on:
   push:
     branches: [main]
@@ -31,7 +28,7 @@ jobs:
       version: ${{ steps.slug.outputs.version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # App Engine version names must be lowercase letters, digits, or hyphens
       # and start with a letter. "ci-<8-char-sha>" satisfies all constraints.
@@ -43,13 +40,12 @@ jobs:
       # The App Engine runtime (nodejs24) and the devDependencies agree on
       # Node 24, so use the same version here for build consistency.
       - name: Set up Node.js 24
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
 
       - name: Install frontend dependencies
-        run: npm install
-        working-directory: front
+        run: npm ci
 
       - name: Authenticate to Google Cloud (staging SA)
         uses: google-github-actions/auth@v2
@@ -145,16 +141,15 @@ jobs:
     environment: production # pauses here for manual approval
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Node.js 24
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
 
       - name: Install frontend dependencies
-        run: npm install
-        working-directory: front
+        run: npm ci
 
       - name: Authenticate to Google Cloud (production SA)
         uses: google-github-actions/auth@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,13 +48,13 @@ jobs:
         run: npm ci
 
       - name: Authenticate to Google Cloud (staging SA)
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ vars.WIF_PROVIDER_STAGING }}
           service_account: ${{ vars.WIF_SA_STAGING }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Deploy to staging
         run: ./deploy.sh -s -v "${{ steps.slug.outputs.version }}"
@@ -152,13 +152,13 @@ jobs:
         run: npm ci
 
       - name: Authenticate to Google Cloud (production SA)
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ vars.WIF_PROVIDER_PROD }}
           service_account: ${{ vars.WIF_SA_PROD }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Deploy to production
         run: ./deploy.sh -p
@@ -175,13 +175,13 @@ jobs:
 
     steps:
       - name: Authenticate to Google Cloud (staging SA)
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ vars.WIF_PROVIDER_STAGING }}
           service_account: ${{ vars.WIF_SA_STAGING }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Delete old staging versions (keep newest 5)
         env:
@@ -228,13 +228,13 @@ jobs:
 
     steps:
       - name: Authenticate to Google Cloud (production SA)
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ vars.WIF_PROVIDER_PROD }}
           service_account: ${{ vars.WIF_SA_PROD }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Delete old production versions (keep newest 5)
         env:


### PR DESCRIPTION
I was a bit tired of always deploying manually so let's automate it.
Basically what it does it's that merging new code on main will automatically push it in staging, will check if it's not completely down and wait for one of us to click before going in prod.
At first I wanted to strictly use our deploy script but then I discovered this: https://docs.cloud.google.com/iam/docs/workload-identity-federation and decided to use it instead since it's safer.
There's a complete guide on how to add the variables and set it up on google cloud so if anyone want's to copy our setup they will be able to do it easily.
Lastly I added some cleanup jobs since I won't be going manually in gcloud to deploy it, we need to clean old versions to avoid huge hosting costs. I chose to keep the last 5 versions in prod and in staging to be able to re route the traffic if something went wrong and we needed to put the website back up quickly.