### PR TITLE
Delegate page: region label + chip restyle

### DIFF
--- a/front/src/components/DelegateCard.tsx
+++ b/front/src/components/DelegateCard.tsx
@@ -3,39 +3,72 @@ import { useTranslation } from "react-i18next";
 import { PersonCard } from "./PersonCard";
 import { Delegate } from "../helpers/fetchDelegates";
 
-// WCA delegate ranks, most senior first. Encoded on the card as a colored chip:
-// primary/filled (top) -> neutral/filled -> primary/outlined -> neutral/outlined.
+// WCA delegate ranks, most senior first. Encoded on the card as a chip whose weight
+// climbs with seniority; red (primary) is reserved for the top rank:
+// primary/filled (top) -> neutral/filled -> neutral/outlined -> neutral/dashed.
 const STATUS_STYLE: Record<
   string,
-  { key: string; color: "primary" | "default"; variant: "filled" | "outlined" }
+  {
+    key: string;
+    color: "primary" | "default";
+    variant: "filled" | "outlined";
+    dashed?: boolean;
+  }
 > = {
   regional_delegate: { key: "regional", color: "primary", variant: "filled" },
   senior_delegate: { key: "senior", color: "primary", variant: "filled" },
   delegate: { key: "delegate", color: "default", variant: "filled" },
-  junior_delegate: { key: "junior", color: "primary", variant: "outlined" },
-  trainee_delegate: { key: "trainee", color: "default", variant: "outlined" },
+  junior_delegate: { key: "junior", color: "default", variant: "outlined" },
+  trainee_delegate: {
+    key: "trainee",
+    color: "default",
+    variant: "outlined",
+    dashed: true,
+  },
 };
 
-// Wraps the presentational PersonCard with delegate-specific concerns: the rank
-// chip (color/variant/label + gendered French wording) and the province subtitle.
-export const DelegateCard = ({ delegate }: { delegate: Delegate }) => {
+// Maps the raw WCA delegate-region group name to a locale key.
+const REGION_GROUP_KEY: Record<string, string> = {
+  "Canada (East)": "east",
+  "Canada (West)": "west",
+};
+
+// Wraps the presentational PersonCard with delegate-specific concerns: the rank chip
+// (color/variant/label + gendered French wording) and a subtitle. Regional delegates
+// (showRegionGroup) show the region they cover; everyone else shows their province.
+export const DelegateCard = ({
+  delegate,
+  showRegionGroup,
+}: {
+  delegate: Delegate;
+  showRegionGroup?: boolean;
+}) => {
   const { t } = useTranslation();
   const style = STATUS_STYLE[delegate.status];
+
+  const regionGroupKey = delegate.region_group
+    ? REGION_GROUP_KEY[delegate.region_group]
+    : undefined;
+  const subtitle =
+    showRegionGroup && regionGroupKey
+      ? t(`delegates.regionGroup.${regionGroupKey}`)
+      : delegate.province
+      ? t(`provinces.${delegate.province}`)
+      : undefined;
 
   return (
     <PersonCard
       wcaId={delegate.wca_id}
       name={delegate.name}
       avatarUrl={delegate.avatar_thumb_url}
-      subtitle={
-        delegate.province ? t(`provinces.${delegate.province}`) : undefined
-      }
+      subtitle={subtitle}
       chip={
         style && (
           <Chip
             size="small"
             color={style.color}
             variant={style.variant}
+            sx={style.dashed ? { borderStyle: "dashed" } : undefined}
             label={t(`delegates.status.${style.key}`, {
               context: delegate.gender === "f" ? "female" : undefined,
             })}

--- a/front/src/locale.ts
+++ b/front/src/locale.ts
@@ -128,6 +128,10 @@ export const resources = {
           junior: "Junior Delegate",
           trainee: "Trainee Delegate",
         },
+        regionGroup: {
+          east: "Canada (East)",
+          west: "Canada (West)",
+        },
       },
       documents: {
         title: "Documents",
@@ -508,6 +512,10 @@ export const resources = {
           junior_female: "Déléguée junior",
           trainee: "Délégué en formation",
           trainee_female: "Déléguée en formation",
+        },
+        regionGroup: {
+          east: "Canada (Est)",
+          west: "Canada (Ouest)",
         },
       },
       documents: {

--- a/front/src/pages/Delegates.test.tsx
+++ b/front/src/pages/Delegates.test.tsx
@@ -9,7 +9,7 @@ const { SAMPLE } = vi.hoisted(() => ({
       name: "Kristopher De Asis",
       gender: "m",
       status: "regional_delegate",
-      province: null,
+      province: "ab",
       region_group: "Canada (West)",
       avatar_thumb_url: null,
     },
@@ -43,15 +43,25 @@ describe("Delegates page", () => {
     renderWithProviders(<Delegates />);
 
     // Every delegate renders (async — waits for the query to resolve).
-    expect(await screen.findByText("Kristopher De Asis")).toBeInTheDocument();
-    expect(screen.getByText("Alexandre Ondet")).toBeInTheDocument();
+    expect(await screen.findByText("Alexandre Ondet")).toBeInTheDocument();
     expect(screen.getByText("Marco Yang")).toBeInTheDocument();
 
-    // Regional delegates get their own priority section...
+    // The regional delegate appears twice: the country-wide priority section...
+    expect(screen.getAllByText("Kristopher De Asis")).toHaveLength(2);
     expect(
       screen.getByRole("heading", { name: i18n.t("delegates.regional") }),
     ).toBeInTheDocument();
-    // ...and the others are grouped by region.
+    // ...where the subtitle is the region they cover, not their province.
+    expect(
+      screen.getByText(i18n.t("delegates.regionGroup.west")),
+    ).toBeInTheDocument();
+
+    // ...and a second time in their home region, alongside per-region delegates.
+    expect(
+      screen.getByRole("heading", {
+        name: i18n.t("championships.regions.pr"),
+      }),
+    ).toBeInTheDocument();
     expect(
       screen.getByRole("heading", {
         name: i18n.t("championships.regions.qc"),
@@ -63,10 +73,10 @@ describe("Delegates page", () => {
       }),
     ).toBeInTheDocument();
 
-    // Rank chips differentiate status.
+    // Rank chips differentiate status (regional shows on both of his cards).
     expect(
-      screen.getByText(i18n.t("delegates.status.regional")),
-    ).toBeInTheDocument();
+      screen.getAllByText(i18n.t("delegates.status.regional")),
+    ).toHaveLength(2);
     expect(
       screen.getByText(i18n.t("delegates.status.junior")),
     ).toBeInTheDocument();

--- a/front/src/pages/Delegates.tsx
+++ b/front/src/pages/Delegates.tsx
@@ -44,13 +44,13 @@ export const Delegates = () => {
   const regional = list
     .filter((delegate) => PRIORITY_STATUSES.includes(delegate.status))
     .sort(byName);
+  // Regional/senior delegates are also listed in their home region (a second time,
+  // alongside the country-wide top section), so no status exclusion here.
   const delegatesInRegion = (region: RegionId) =>
     list
       .filter(
         (delegate) =>
-          !PRIORITY_STATUSES.includes(delegate.status) &&
-          delegate.province &&
-          PROVINCE_REGION[delegate.province] === region,
+          delegate.province && PROVINCE_REGION[delegate.province] === region,
       )
       .sort(byName);
 
@@ -83,7 +83,15 @@ export const Delegates = () => {
               >
                 {t("delegates.regional")}
               </Typography>
-              <CardGrid>{regional.map(renderDelegateCard)}</CardGrid>
+              <CardGrid>
+                {regional.map((delegate) => (
+                  <DelegateCard
+                    key={delegate.wca_id}
+                    delegate={delegate}
+                    showRegionGroup
+                  />
+                ))}
+              </CardGrid>
             </Box>
           )}
 

--- a/front/src/pages/Delegates.tsx
+++ b/front/src/pages/Delegates.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useQuery } from "@tanstack/react-query";
 import { DelegateCard } from "../components/DelegateCard";
 import { LoadingPageLinear } from "../components/LoadingPageLinear";
-import { fetchDelegates, Delegate } from "../helpers/fetchDelegates";
+import { fetchDelegates } from "../helpers/fetchDelegates";
 import {
   PROVINCE_REGION,
   REGION_ORDER,
@@ -53,10 +53,6 @@ export const Delegates = () => {
           delegate.province && PROVINCE_REGION[delegate.province] === region,
       )
       .sort(byName);
-
-  const renderDelegateCard = (delegate: Delegate) => (
-    <DelegateCard key={delegate.wca_id} delegate={delegate} />
-  );
 
   return (
     <Container maxWidth="md">
@@ -111,7 +107,11 @@ export const Delegates = () => {
                 >
                   {t(`championships.regions.${region}`)}
                 </Typography>
-                <CardGrid>{regionDelegates.map(renderDelegateCard)}</CardGrid>
+                <CardGrid>
+                  {regionDelegates.map((delegate) => (
+                    <DelegateCard key={delegate.wca_id} delegate={delegate} />
+                  ))}
+                </CardGrid>
               </Box>
             );
           })}


### PR DESCRIPTION
- Regional delegates show their WCA region (Canada East/West) and now also appear in their province's group.
- Role chips: red reserved for the top rank; junior/trainee differ by border style, not colour.