### PR TITLE
chore(deps): bump undici from 7.28.0 to 7.29.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5610,9 +5610,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Splits the undici half out of the grouped Dependabot PR #161 so the security
fix can land without the react-router 8 major.

undici is dev-only — it reaches us solely through jsdom, the vitest DOM
environment — so there's no App Engine exposure. Picks up four upstream fixes,
one high (GHSA-4cwx-7wf7-3272). Lockfile only; `front/package.json` untouched.

### Why not the rest of #161

- react-router 8 requires `react >= 19.2.7` and imports `useOptimistic`. We're
  on React 18.3.1 — that's why #161's Tests job fails.
- react-admin 5.15.1 still caps react-router at `^6.28.1 || ^7.1.1`
  (marmelab/react-admin#11289 still open). #161 works around this by nesting
  RR8 under `front/node_modules` while react-admin keeps 7.18.2 — two routers,
  and `AdminPage` loses router context.
- React 19 is separately blocked by `@mui/x-data-grid@^6` / `@mui/x-date-pickers@^6`.

The advisory driving #161 (GHSA-qwww-vcr4-c8h2) only affects the unstable RSC
APIs. This is a client-only SPA — `server.js` never imports react-router — so
it doesn't apply.

### Verification

- `npm run test --workspace front` — 6 files / 7 tests pass
- `npm run build --workspace front` — succeeds
- `node_modules/react-router` still 7.18.2, no nested copies