### PR TITLE
fix CSP policy

### DIFF
--- a/front/server.js
+++ b/front/server.js
@@ -68,7 +68,7 @@ app.use(
     contentSecurityPolicy: {
       useDefaults: false,
       directives: {
-        "default-src": ["'none'"],
+        "default-src": ["'self'"],
         "base-uri": ["'self'"],
         "form-action": ["'self'"],
         "frame-ancestors": ["'none'"],


### PR DESCRIPTION
Firefox checks prefetch-class speculative loads of JS chunks against `default-src` instead of `script-src` can cause issues. This policy change fixes it.