### PR TITLE
Cache WCA avatars server-side for the Organization page

### DIFF
--- a/back/backend/handlers/admin/edit_teams.py
+++ b/back/backend/handlers/admin/edit_teams.py
@@ -32,6 +32,9 @@ def parse_members(raw_members):
                 bio_en=(row.get("bio_en") or "").strip() or None,
                 bio_fr=(row.get("bio_fr") or "").strip() or None,
                 is_leader=bool(row.get("is_leader")),
+                # Preserved verbatim from the round-tripped record ("" is the
+                # synced-default-avatar sentinel, so no strip-to-None).
+                avatar_thumb_url=row.get("avatar_thumb_url"),
             )
         )
     return members

--- a/back/backend/handlers/admin/edit_teams.py
+++ b/back/backend/handlers/admin/edit_teams.py
@@ -32,8 +32,7 @@ def parse_members(raw_members):
                 bio_en=(row.get("bio_en") or "").strip() or None,
                 bio_fr=(row.get("bio_fr") or "").strip() or None,
                 is_leader=bool(row.get("is_leader")),
-                # Preserved verbatim from the round-tripped record ("" is the
-                # synced-default-avatar sentinel, so no strip-to-None).
+                # Do not normalize this field: empty string and None have distinct meanings
                 avatar_thumb_url=row.get("avatar_thumb_url"),
             )
         )

--- a/back/backend/load_db/load_db.py
+++ b/back/backend/load_db/load_db.py
@@ -5,6 +5,7 @@ from backend.load_db.setup_geography import setup_regions_and_provinces
 from backend.load_db.update_champions import update_champions
 from backend.load_db.update_championships import update_championships
 from backend.load_db.update_delegates import update_delegates
+from backend.load_db.update_org_avatars import update_org_avatars
 from backend.load_db.update_province_records import update_province_records
 from backend.models.user import User
 from backend.models.wca.competition import Competition
@@ -35,6 +36,7 @@ flags.DEFINE_boolean("only_update_championships", False, "Whether to only update
 flags.DEFINE_boolean("only_update_champions", False, "Whether to only update champions.")
 flags.DEFINE_boolean("only_update_province_records", False, "Whether to only update province records.")
 flags.DEFINE_boolean("only_update_delegates", False, "Whether to only update delegates.")
+flags.DEFINE_boolean("only_update_org_avatars", False, "Whether to only update Organization-page avatars.")
 
 
 def get_tables():
@@ -189,6 +191,7 @@ def main(argv):
         and not FLAGS.only_update_championships
         and not FLAGS.only_update_province_records
         and not FLAGS.only_update_delegates
+        and not FLAGS.only_update_org_avatars
     )
 
     if do_everything or FLAGS.only_load_db:
@@ -218,6 +221,8 @@ def main(argv):
             update_province_records()
         if do_everything or FLAGS.only_update_delegates:
             update_delegates()
+        if do_everything or FLAGS.only_update_org_avatars:
+            update_org_avatars()
 
     if _stale_cache_count:
         logging.error(

--- a/back/backend/load_db/load_db.sh
+++ b/back/backend/load_db/load_db.sh
@@ -22,8 +22,7 @@ LATEST_EXPORT=$(curl https://www.worldcubeassociation.org/export/results \
 if [ "$SAVED_EXPORT" == "$LATEST_EXPORT" ]
 then
   echo "Already have latest export $LATEST_EXPORT; nothing to download."
-  # Avatars change independently of WCA exports; refresh them (and the delegate
-  # roster) nightly even when there is no new export to load.
+  # Avatars and delegates can change without a new export; refresh nightly.
   python3 backend/load_db/load_db.py --only_update_delegates --only_update_org_avatars
 fi
 

--- a/back/backend/load_db/load_db.sh
+++ b/back/backend/load_db/load_db.sh
@@ -22,6 +22,9 @@ LATEST_EXPORT=$(curl https://www.worldcubeassociation.org/export/results \
 if [ "$SAVED_EXPORT" == "$LATEST_EXPORT" ]
 then
   echo "Already have latest export $LATEST_EXPORT; nothing to download."
+  # Avatars change independently of WCA exports; refresh them (and the delegate
+  # roster) nightly even when there is no new export to load.
+  python3 backend/load_db/load_db.py --only_update_delegates --only_update_org_avatars
 fi
 
 if [ "$SAVED_EXPORT" != "$LATEST_EXPORT" ]

--- a/back/backend/load_db/update_org_avatars.py
+++ b/back/backend/load_db/update_org_avatars.py
@@ -17,9 +17,8 @@ _DELAY_SECONDS = 1
 def _fetch_avatar(wca_id):
     """Fetch a person's avatar thumb URL from the WCA API.
 
-    Returns the URL, "" for a default avatar (synced-but-no-photo sentinel), or
-    None on any failure (meaning "leave the stored value alone" — never downgrade
-    an existing avatar on a transient error).
+    Returns None if fetching fails. Otherwise returns the avatar thumb URL,
+    or "" if the person has the default avatar.
     """
     try:
         resp = requests.get(_WCA_PERSON_URL + wca_id, timeout=30)
@@ -37,12 +36,9 @@ def _fetch_avatar(wca_id):
 
 
 def update_org_avatars():
-    """Sync WCA avatars for Organization-page people (team members, directors,
-    featured members) into the datastore.
+    """Sync WCA avatars for Organization-page people into the datastore.
 
-    Each person is independent: fetch failures skip that person and self-heal on
-    the next nightly run, so there is no all-or-nothing abort. Must run inside an
-    active ``ndb`` context (opened by ``load_db.main``).
+    Fetch failures skip that person. Requires an active ``ndb`` context.
     """
     teams = list(Team.query().iter())
     people = list(Director.query().iter()) + list(FeaturedMember.query().iter())

--- a/back/backend/load_db/update_org_avatars.py
+++ b/back/backend/load_db/update_org_avatars.py
@@ -1,0 +1,82 @@
+import logging
+import time
+
+import requests
+from backend.models.site_person import Director, FeaturedMember
+from backend.models.team import Team
+from google.cloud import ndb
+
+logger = logging.getLogger(__name__)
+
+_WCA_PERSON_URL = "https://www.worldcubeassociation.org/api/v0/persons/"
+
+# ponytail: serial 1 req/s is plenty for ~30 people; batch/parallelize if the roster ever grows 10x.
+_DELAY_SECONDS = 1
+
+
+def _fetch_avatar(wca_id):
+    """Fetch a person's avatar thumb URL from the WCA API.
+
+    Returns the URL, "" for a default avatar (synced-but-no-photo sentinel), or
+    None on any failure (meaning "leave the stored value alone" — never downgrade
+    an existing avatar on a transient error).
+    """
+    try:
+        resp = requests.get(_WCA_PERSON_URL + wca_id, timeout=30)
+    except requests.RequestException:
+        logger.exception("WCA person fetch failed for %s", wca_id)
+        return None
+    if resp.status_code != 200:
+        logger.error("WCA person fetch returned %s for %s", resp.status_code, wca_id)
+        return None
+
+    avatar = (resp.json().get("person") or {}).get("avatar") or {}
+    if avatar.get("is_default"):
+        return ""
+    return avatar.get("thumb_url") or ""
+
+
+def update_org_avatars():
+    """Sync WCA avatars for Organization-page people (team members, directors,
+    featured members) into the datastore.
+
+    Each person is independent: fetch failures skip that person and self-heal on
+    the next nightly run, so there is no all-or-nothing abort. Must run inside an
+    active ``ndb`` context (opened by ``load_db.main``).
+    """
+    teams = list(Team.query().iter())
+    people = list(Director.query().iter()) + list(FeaturedMember.query().iter())
+
+    wca_ids = {m.wca_id for t in teams for m in t.members if m.wca_id}
+    wca_ids |= {p.wca_id for p in people if p.wca_id}
+
+    avatars = {}
+    for wca_id in sorted(wca_ids):
+        result = _fetch_avatar(wca_id)
+        if result is not None:
+            avatars[wca_id] = result
+        time.sleep(_DELAY_SECONDS)
+
+    to_write = []
+    for team in teams:
+        changed = False
+        for member in team.members:
+            new = avatars.get(member.wca_id)
+            if new is not None and member.avatar_thumb_url != new:
+                member.avatar_thumb_url = new
+                changed = True
+        if changed:
+            to_write.append(team)
+    for person in people:
+        new = avatars.get(person.wca_id)
+        if new is not None and person.avatar_thumb_url != new:
+            person.avatar_thumb_url = new
+            to_write.append(person)
+
+    ndb.put_multi(to_write)
+    logger.info(
+        "Synced avatars for %d of %d people (%d entities written).",
+        len(avatars),
+        len(wca_ids),
+        len(to_write),
+    )

--- a/back/backend/models/site_person.py
+++ b/back/backend/models/site_person.py
@@ -12,6 +12,9 @@ class _PersonRecord(ndb.Model):
     bio_en = ndb.StringProperty()
     bio_fr = ndb.StringProperty()
     position = ndb.IntegerProperty(default=0)
+    # WCA avatar thumbnail synced server-side; "" = synced but default avatar,
+    # None = not yet synced (frontend falls back to a client-side WCA fetch).
+    avatar_thumb_url = ndb.StringProperty()
 
     def to_json(self):
         return {
@@ -23,6 +26,7 @@ class _PersonRecord(ndb.Model):
             "bio_en": self.bio_en,
             "bio_fr": self.bio_fr,
             "position": self.position or 0,
+            "avatar_thumb_url": self.avatar_thumb_url,
         }
 
 

--- a/back/backend/models/site_person.py
+++ b/back/backend/models/site_person.py
@@ -12,8 +12,7 @@ class _PersonRecord(ndb.Model):
     bio_en = ndb.StringProperty()
     bio_fr = ndb.StringProperty()
     position = ndb.IntegerProperty(default=0)
-    # WCA avatar thumbnail synced server-side; "" = synced but default avatar,
-    # None = not yet synced (frontend falls back to a client-side WCA fetch).
+    # WCA avatar thumbnail synced server-side; "" = synced but default avatar, None = not yet synced.
     avatar_thumb_url = ndb.StringProperty()
 
     def to_json(self):

--- a/back/backend/models/team.py
+++ b/back/backend/models/team.py
@@ -9,8 +9,7 @@ class TeamMember(ndb.Model):
     bio_en = ndb.StringProperty()
     bio_fr = ndb.StringProperty()
     is_leader = ndb.BooleanProperty(default=False)
-    # WCA avatar thumbnail synced server-side; "" = synced but default avatar,
-    # None = not yet synced (frontend falls back to a client-side WCA fetch).
+    # WCA avatar thumbnail synced server-side; "" = synced but default avatar, None = not yet synced.
     avatar_thumb_url = ndb.StringProperty()
 
     def to_json(self):

--- a/back/backend/models/team.py
+++ b/back/backend/models/team.py
@@ -9,6 +9,9 @@ class TeamMember(ndb.Model):
     bio_en = ndb.StringProperty()
     bio_fr = ndb.StringProperty()
     is_leader = ndb.BooleanProperty(default=False)
+    # WCA avatar thumbnail synced server-side; "" = synced but default avatar,
+    # None = not yet synced (frontend falls back to a client-side WCA fetch).
+    avatar_thumb_url = ndb.StringProperty()
 
     def to_json(self):
         return {
@@ -17,6 +20,7 @@ class TeamMember(ndb.Model):
             "bio_en": self.bio_en,
             "bio_fr": self.bio_fr,
             "is_leader": bool(self.is_leader),
+            "avatar_thumb_url": self.avatar_thumb_url,
         }
 
 

--- a/back/tests/test_people.py
+++ b/back/tests/test_people.py
@@ -22,6 +22,7 @@ def test_person_to_json_shape():
     member.bio_en = "Started it all."
     member.bio_fr = "A tout démarré."
     member.position = 1
+    member.avatar_thumb_url = "thumb.jpg"
 
     assert FeaturedMember.to_json(member) == {
         "id": "jane",
@@ -32,6 +33,7 @@ def test_person_to_json_shape():
         "bio_en": "Started it all.",
         "bio_fr": "A tout démarré.",
         "position": 1,
+        "avatar_thumb_url": "thumb.jpg",
     }
 
 

--- a/back/tests/test_teams.py
+++ b/back/tests/test_teams.py
@@ -86,7 +86,7 @@ def test_parse_members_maps_fields_and_skips_blank_names():
     assert members[0].bio_fr is None
     assert members[0].is_leader is True
     assert members[1].wca_id is None
-    # avatar_thumb_url round-trips verbatim: "" (synced default avatar) must survive.
+    # "" (synced default) must survive round-trip.
     assert members[0].avatar_thumb_url == "thumb.jpg"
     assert members[1].avatar_thumb_url == ""
 

--- a/back/tests/test_teams.py
+++ b/back/tests/test_teams.py
@@ -22,7 +22,16 @@ def test_team_to_json_shape():
     team.description_en = "We build the site."
     team.description_fr = "On construit le site."
     team.position = 2
-    team.members = [TeamMember(name="Alex", wca_id="2017ONDE01", bio_en="Bio", bio_fr="Bio fr", is_leader=True)]
+    team.members = [
+        TeamMember(
+            name="Alex",
+            wca_id="2017ONDE01",
+            bio_en="Bio",
+            bio_fr="Bio fr",
+            is_leader=True,
+            avatar_thumb_url="thumb.jpg",
+        )
+    ]
 
     assert Team.to_json(team) == {
         "id": "software",
@@ -38,6 +47,7 @@ def test_team_to_json_shape():
                 "bio_en": "Bio",
                 "bio_fr": "Bio fr",
                 "is_leader": True,
+                "avatar_thumb_url": "thumb.jpg",
             }
         ],
     }
@@ -57,9 +67,16 @@ def test_team_to_json_defaults_position_and_empty_members():
 
 def test_parse_members_maps_fields_and_skips_blank_names():
     rows = [
-        {"name": "Lead", "wca_id": "2008ASIS01", "bio_en": "b", "bio_fr": "", "is_leader": True},
+        {
+            "name": "Lead",
+            "wca_id": "2008ASIS01",
+            "bio_en": "b",
+            "bio_fr": "",
+            "is_leader": True,
+            "avatar_thumb_url": "thumb.jpg",
+        },
         {"name": "  ", "wca_id": "X", "is_leader": False},  # blank name -> skipped
-        {"name": "Member", "wca_id": "", "is_leader": False},  # empty wca_id -> None
+        {"name": "Member", "wca_id": "", "is_leader": False, "avatar_thumb_url": ""},  # empty wca_id -> None
     ]
 
     members = parse_members(rows)
@@ -69,6 +86,9 @@ def test_parse_members_maps_fields_and_skips_blank_names():
     assert members[0].bio_fr is None
     assert members[0].is_leader is True
     assert members[1].wca_id is None
+    # avatar_thumb_url round-trips verbatim: "" (synced default avatar) must survive.
+    assert members[0].avatar_thumb_url == "thumb.jpg"
+    assert members[1].avatar_thumb_url == ""
 
 
 def test_parse_members_handles_none():

--- a/back/tests/test_update_org_avatars.py
+++ b/back/tests/test_update_org_avatars.py
@@ -1,7 +1,4 @@
-"""Unit tests for the Organization-page avatar sync helpers.
-
-Pure logic only (mocked requests), mirroring test_delegates.py - no datastore emulator.
-"""
+"""Unit tests for _fetch_avatar (mocked requests, no datastore emulator)."""
 
 from unittest.mock import MagicMock, patch
 
@@ -14,9 +11,6 @@ def _response(status_code=200, person=None):
     resp.status_code = status_code
     resp.json.return_value = {"person": person}
     return resp
-
-
-# _fetch_avatar
 
 
 @patch("backend.load_db.update_org_avatars.requests.get")
@@ -41,7 +35,7 @@ def test_fetch_avatar_missing_thumb_url_is_empty_string(mock_get):
 
 @patch("backend.load_db.update_org_avatars.requests.get")
 def test_fetch_avatar_non_200_is_none(mock_get):
-    # None = "leave the stored value alone", so a 429/404 never wipes an avatar.
+    # a non-200 must never wipe a stored avatar.
     for status in (404, 429, 500):
         mock_get.return_value = _response(status_code=status)
         assert _fetch_avatar("2017ONDE01") is None

--- a/back/tests/test_update_org_avatars.py
+++ b/back/tests/test_update_org_avatars.py
@@ -1,0 +1,53 @@
+"""Unit tests for the Organization-page avatar sync helpers.
+
+Pure logic only (mocked requests), mirroring test_delegates.py - no datastore emulator.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import requests
+from backend.load_db.update_org_avatars import _fetch_avatar
+
+
+def _response(status_code=200, person=None):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = {"person": person}
+    return resp
+
+
+# _fetch_avatar
+
+
+@patch("backend.load_db.update_org_avatars.requests.get")
+def test_fetch_avatar_returns_thumb_url(mock_get):
+    mock_get.return_value = _response(person={"avatar": {"is_default": False, "thumb_url": "thumb.jpg"}})
+    assert _fetch_avatar("2017ONDE01") == "thumb.jpg"
+
+
+@patch("backend.load_db.update_org_avatars.requests.get")
+def test_fetch_avatar_default_avatar_is_empty_string(mock_get):
+    mock_get.return_value = _response(person={"avatar": {"is_default": True, "thumb_url": "default.jpg"}})
+    assert _fetch_avatar("2017ONDE01") == ""
+
+
+@patch("backend.load_db.update_org_avatars.requests.get")
+def test_fetch_avatar_missing_thumb_url_is_empty_string(mock_get):
+    mock_get.return_value = _response(person={"avatar": {"is_default": False}})
+    assert _fetch_avatar("2017ONDE01") == ""
+    mock_get.return_value = _response(person={})
+    assert _fetch_avatar("2017ONDE01") == ""
+
+
+@patch("backend.load_db.update_org_avatars.requests.get")
+def test_fetch_avatar_non_200_is_none(mock_get):
+    # None = "leave the stored value alone", so a 429/404 never wipes an avatar.
+    for status in (404, 429, 500):
+        mock_get.return_value = _response(status_code=status)
+        assert _fetch_avatar("2017ONDE01") is None
+
+
+@patch("backend.load_db.update_org_avatars.requests.get")
+def test_fetch_avatar_request_exception_is_none(mock_get):
+    mock_get.side_effect = requests.ConnectionError()
+    assert _fetch_avatar("2017ONDE01") is None

--- a/front/src/components/FeaturedMemberCard.tsx
+++ b/front/src/components/FeaturedMemberCard.tsx
@@ -11,8 +11,7 @@ import { LINKS } from "../pages/links";
 // "Featured Members" section of the Organization page.
 export const FeaturedMemberCard = ({ member }: { member: FeaturedMember }) => {
   const wcaId = member.wca_id ?? undefined;
-  // Only hit the WCA API for people not yet synced server-side (null); "" means
-  // synced with a default avatar, a URL means synced with a photo.
+  // null = not yet synced server-side; only then fall back to a WCA fetch.
   const shouldFetch = member.avatar_thumb_url == null && !!wcaId;
 
   const { data } = useQuery({

--- a/front/src/components/FeaturedMemberCard.tsx
+++ b/front/src/components/FeaturedMemberCard.tsx
@@ -11,16 +11,22 @@ import { LINKS } from "../pages/links";
 // "Featured Members" section of the Organization page.
 export const FeaturedMemberCard = ({ member }: { member: FeaturedMember }) => {
   const wcaId = member.wca_id ?? undefined;
+  // Only hit the WCA API for people not yet synced server-side (null); "" means
+  // synced with a default avatar, a URL means synced with a photo.
+  const shouldFetch = member.avatar_thumb_url == null && !!wcaId;
 
   const { data } = useQuery({
     queryKey: ["wca-person", wcaId],
     queryFn: () => fetchWcaPerson(wcaId as string),
     staleTime: 1000 * 60 * 60,
-    enabled: !!wcaId,
+    enabled: shouldFetch,
   });
 
-  const avatar =
-    data && !data.avatarIsDefault ? data.avatarThumbUrl : undefined;
+  const avatar = shouldFetch
+    ? data && !data.avatarIsDefault
+      ? data.avatarThumbUrl
+      : undefined
+    : member.avatar_thumb_url || undefined;
   const name = member.name ?? "";
   const role = localized(member, "role");
   const bio = localized(member, "bio");

--- a/front/src/helpers/fetchPeople.ts
+++ b/front/src/helpers/fetchPeople.ts
@@ -11,8 +11,7 @@ export interface PersonRecord {
   bio_en: string | null;
   bio_fr: string | null;
   position: number;
-  // Server-synced WCA avatar; "" = synced but default avatar, null = not yet
-  // synced (card falls back to a client-side WCA fetch).
+  // "" = synced, default avatar; null = not yet synced (card falls back to a WCA fetch).
   avatar_thumb_url: string | null;
 }
 

--- a/front/src/helpers/fetchPeople.ts
+++ b/front/src/helpers/fetchPeople.ts
@@ -11,6 +11,9 @@ export interface PersonRecord {
   bio_en: string | null;
   bio_fr: string | null;
   position: number;
+  // Server-synced WCA avatar; "" = synced but default avatar, null = not yet
+  // synced (card falls back to a client-side WCA fetch).
+  avatar_thumb_url: string | null;
 }
 
 export type Director = PersonRecord;

--- a/front/src/helpers/fetchTeams.ts
+++ b/front/src/helpers/fetchTeams.ts
@@ -8,6 +8,9 @@ export interface TeamMember {
   bio_en: string | null;
   bio_fr: string | null;
   is_leader: boolean;
+  // Server-synced WCA avatar; "" = synced but default avatar, null = not yet
+  // synced (card falls back to a client-side WCA fetch).
+  avatar_thumb_url: string | null;
 }
 
 export interface Team {

--- a/front/src/helpers/fetchTeams.ts
+++ b/front/src/helpers/fetchTeams.ts
@@ -8,8 +8,7 @@ export interface TeamMember {
   bio_en: string | null;
   bio_fr: string | null;
   is_leader: boolean;
-  // Server-synced WCA avatar; "" = synced but default avatar, null = not yet
-  // synced (card falls back to a client-side WCA fetch).
+  // "" = synced, default avatar; null = not yet synced (card falls back to a WCA fetch).
   avatar_thumb_url: string | null;
 }
 

--- a/front/src/pages/Organization.test.tsx
+++ b/front/src/pages/Organization.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from "@testing-library/react";
 import { renderWithProviders, i18n } from "../test/renderWithProviders";
 import { Organization } from "./Organization";
+import { fetchWcaPerson } from "../helpers/fetchWcaPerson";
 
 const { DIRECTORS, FEATURED, TEAMS } = vi.hoisted(() => ({
   DIRECTORS: [
@@ -13,6 +14,8 @@ const { DIRECTORS, FEATURED, TEAMS } = vi.hoisted(() => ({
       bio_en: null,
       bio_fr: null,
       position: 0,
+      // Synced server-side: rendered directly, no WCA fetch.
+      avatar_thumb_url: "https://avatars.example/kris.jpg",
     },
   ],
   FEATURED: [
@@ -25,6 +28,7 @@ const { DIRECTORS, FEATURED, TEAMS } = vi.hoisted(() => ({
       bio_en: "Started it all.",
       bio_fr: "A tout démarré.",
       position: 0,
+      avatar_thumb_url: null,
     },
   ],
   TEAMS: [
@@ -42,6 +46,8 @@ const { DIRECTORS, FEATURED, TEAMS } = vi.hoisted(() => ({
           bio_en: null,
           bio_fr: null,
           is_leader: true,
+          // Synced, WCA default avatar: no fetch, generic icon.
+          avatar_thumb_url: "",
         },
         {
           name: "Sam Smith",
@@ -49,6 +55,16 @@ const { DIRECTORS, FEATURED, TEAMS } = vi.hoisted(() => ({
           bio_en: null,
           bio_fr: null,
           is_leader: false,
+          avatar_thumb_url: null,
+        },
+        {
+          name: "Nina New",
+          wca_id: "2026NEWN01",
+          bio_en: null,
+          bio_fr: null,
+          is_leader: false,
+          // Not yet synced: the card falls back to a client-side WCA fetch.
+          avatar_thumb_url: null,
         },
       ],
     },
@@ -72,6 +88,10 @@ vi.mock("../helpers/fetchTeams", () => ({
 }));
 
 describe("Organization page", () => {
+  // Both tests render the page (and its one fallback WCA fetch); reset call
+  // history so the per-test call-count assertion stays accurate.
+  beforeEach(() => vi.mocked(fetchWcaPerson).mockClear());
+
   it("renders the board, featured members and teams", async () => {
     renderWithProviders(<Organization />);
 
@@ -103,5 +123,20 @@ describe("Organization page", () => {
     expect(screen.getByText("Alex Mutch")).toBeInTheDocument();
     expect(screen.getByText("Sam Smith")).toBeInTheDocument();
     expect(screen.getByText(i18n.t("teams.leader"))).toBeInTheDocument();
+  });
+
+  it("uses server-synced avatars and only fetches WCA for unsynced people", async () => {
+    renderWithProviders(<Organization />);
+
+    // Synced avatar is rendered straight from the backend field.
+    const avatar = await screen.findByRole("img", {
+      name: "Kristopher De Asis",
+    });
+    expect(avatar).toHaveAttribute("src", "https://avatars.example/kris.jpg");
+
+    // Only the not-yet-synced person (null avatar_thumb_url + wca_id) hits WCA;
+    // synced people ("" or URL) and people without a wca_id must not.
+    expect(vi.mocked(fetchWcaPerson)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(fetchWcaPerson)).toHaveBeenCalledWith("2026NEWN01");
   });
 });

--- a/front/src/pages/Organization.test.tsx
+++ b/front/src/pages/Organization.test.tsx
@@ -14,7 +14,7 @@ const { DIRECTORS, FEATURED, TEAMS } = vi.hoisted(() => ({
       bio_en: null,
       bio_fr: null,
       position: 0,
-      // Synced server-side: rendered directly, no WCA fetch.
+      // synced
       avatar_thumb_url: "https://avatars.example/kris.jpg",
     },
   ],
@@ -46,7 +46,7 @@ const { DIRECTORS, FEATURED, TEAMS } = vi.hoisted(() => ({
           bio_en: null,
           bio_fr: null,
           is_leader: true,
-          // Synced, WCA default avatar: no fetch, generic icon.
+          // synced, default avatar
           avatar_thumb_url: "",
         },
         {
@@ -63,7 +63,7 @@ const { DIRECTORS, FEATURED, TEAMS } = vi.hoisted(() => ({
           bio_en: null,
           bio_fr: null,
           is_leader: false,
-          // Not yet synced: the card falls back to a client-side WCA fetch.
+          // not yet synced
           avatar_thumb_url: null,
         },
       ],
@@ -88,8 +88,7 @@ vi.mock("../helpers/fetchTeams", () => ({
 }));
 
 describe("Organization page", () => {
-  // Both tests render the page (and its one fallback WCA fetch); reset call
-  // history so the per-test call-count assertion stays accurate.
+  // reset call history for the call-count assertion
   beforeEach(() => vi.mocked(fetchWcaPerson).mockClear());
 
   it("renders the board, featured members and teams", async () => {
@@ -128,14 +127,12 @@ describe("Organization page", () => {
   it("uses server-synced avatars and only fetches WCA for unsynced people", async () => {
     renderWithProviders(<Organization />);
 
-    // Synced avatar is rendered straight from the backend field.
     const avatar = await screen.findByRole("img", {
       name: "Kristopher De Asis",
     });
     expect(avatar).toHaveAttribute("src", "https://avatars.example/kris.jpg");
 
-    // Only the not-yet-synced person (null avatar_thumb_url + wca_id) hits WCA;
-    // synced people ("" or URL) and people without a wca_id must not.
+    // only the not-yet-synced person with a wca_id hits WCA
     expect(vi.mocked(fetchWcaPerson)).toHaveBeenCalledTimes(1);
     expect(vi.mocked(fetchWcaPerson)).toHaveBeenCalledWith("2026NEWN01");
   });

--- a/front/src/pages/Organization.tsx
+++ b/front/src/pages/Organization.tsx
@@ -74,6 +74,7 @@ export const Organization = () => {
                 key={director.id}
                 wcaId={director.wca_id ?? undefined}
                 name={director.name ?? ""}
+                avatarUrl={director.avatar_thumb_url ?? undefined}
                 subtitle={
                   localized(director, "role") ?? t("directors.boardMember")
                 }
@@ -131,6 +132,7 @@ export const Organization = () => {
                       key={member.wca_id ?? `${team.id}-${index}`}
                       wcaId={member.wca_id ?? undefined}
                       name={member.name}
+                      avatarUrl={member.avatar_thumb_url ?? undefined}
                       chip={
                         member.is_leader ? (
                           <Chip

--- a/package-lock.json
+++ b/package-lock.json
@@ -3283,9 +3283,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -4642,9 +4642,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
- The org page fired ~30 browser requests to the WCA persons API and got 429s; avatars are now synced nightly into the DB like the delegate roster.
- "" = synced but default avatar, null = not yet synced (card falls back to the client-side fetch until the next run).
- load_db.sh now also syncs on no-export nights, so delegate avatars refresh nightly too.
- parse_members preserves avatar_thumb_url so admin saves don't wipe them.